### PR TITLE
Use an interface to implement the ses|pinpoint relay clients.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 *
+!internal/auth/auth.go
 !internal/relay/relay.go
 !internal/relay/pinpoint/relay.go
 !internal/relay/ses/relay.go

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 !internal/relay/relay.go
 !internal/relay/pinpoint/relay.go
 !internal/relay/ses/relay.go
+!internal/request/request.go
 !main.go
 !go.mod
 !go.sum

--- a/README.md
+++ b/README.md
@@ -22,11 +22,13 @@
 - [License](#license)
 
 ## Background
-[AWS SES](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/Welcome.html)
-and [Pinpoint](https://docs.aws.amazon.com/pinpoint/latest/developerguide/welcome.html) provide an
-[API](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-api.html)
-and an [SMTP interface](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-smtp.html)
-to send emails.
+[Amazon SES](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/Welcome.html)
+and [Amazon Pinpoint](https://docs.aws.amazon.com/pinpoint/latest/developerguide/welcome.html)
+both provide an API and an SMTP interface to send emails:
+* [SES Email API](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-api.html)
+* [SES SMTP interface](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-smtp.html)
+* [Pinpoint EmailAPI](https://docs.aws.amazon.com/pinpoint/latest/developerguide/send-messages-email-sdk.html)
+* [Pinpoint SMTP interface](https://docs.aws.amazon.com/pinpoint/latest/developerguide/send-messages-email-smtp.html)
 
 The SMTP interface is useful for applications that must use SMTP to send emails,
 but it requires providing a set of SMTP credentials:
@@ -35,7 +37,8 @@ but it requires providing a set of SMTP credentials:
 
 For security reasons, using
 [IAM roles](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html)
-is preferable, but only possible with the SES/Pinpoint APIs and not the SMTP interface.
+is preferable, but only possible with the Email API and not the SMTP
+interface.
 
 This is where this project comes into play, as it provides an SMTP interface
 that relays emails via SES or Pinpoint API using IAM roles.
@@ -81,7 +84,7 @@ Usage of aws-smtp-relay:
   -c string
     	TLS cert file
   -e string
-    Amazon SES Configuration Set Name
+    	Amazon SES Configuration Set Name
   -h string
     	Server hostname
   -i string
@@ -89,10 +92,11 @@ Usage of aws-smtp-relay:
   -k string
     	TLS key file
   -n string
+    	SMTP service name (default "AWS SMTP Relay")
+  -r string
+    	Relay API to use (ses|pinpoint) (default "ses")
   -s	Require TLS via STARTTLS extension
   -t	Listen for incoming TLS connections only
-  -r string
-    Relay API to use (ses|pinpoint) (default "ses")
   -u string
     	Authentication username
 ```

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -1,0 +1,51 @@
+/*
+Package auth provides an IP and user credentials based authentication handler.
+*/
+package auth
+
+import (
+	"errors"
+	"net"
+
+	"golang.org/x/crypto/bcrypt"
+)
+
+// Authentication implements the AuthHandler interface.
+type Authentication struct {
+	ips  map[string]bool
+	user string
+	hash []byte
+}
+
+// Handler validates remote IPs and user credentials.
+func (a Authentication) Handler(
+	remoteAddr net.Addr,
+	mechanism string,
+	username []byte,
+	password []byte,
+	shared []byte,
+) (bool, error) {
+	if a.ips != nil {
+		ip := remoteAddr.(*net.TCPAddr).IP.String()
+		if a.ips[ip] != true {
+			return false, errors.New("Invalid client IP: " + ip)
+		}
+	}
+	if a.user != "" {
+		if string(username) != a.user {
+			return false, errors.New("Invalid username: " + string(username))
+		}
+		err := bcrypt.CompareHashAndPassword(a.hash, password)
+		return err == nil, err
+	}
+	return true, nil
+}
+
+// New creates a new Authentication config.
+func New(ips map[string]bool, user string, hash []byte) Authentication {
+	return Authentication{
+		ips:  ips,
+		user: user,
+		hash: hash,
+	}
+}

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -1,0 +1,130 @@
+package auth
+
+import (
+	"net"
+	"testing"
+)
+
+// bcrypt hash for the string "password"
+var sampleHash = "$2y$10$85/eICRuwBwutrou64G5HeoF3Ek/qf1YKPLba7ckiMxUTAeLIeyaC"
+
+func TestHandler(t *testing.T) {
+	ipMap := map[string]bool{"127.0.0.1": true, "2001:4860:0:2001::68": true}
+	user := "username"
+	bcryptHash := []byte(sampleHash)
+	origin := net.TCPAddr{IP: []byte{127, 0, 0, 1}}
+	auth := New(ipMap, user, bcryptHash)
+	success, err := auth.Handler(
+		&origin,
+		"LOGIN",
+		[]byte("username"),
+		[]byte("password"),
+		nil,
+	)
+	if success != true {
+		t.Errorf("Unexpected authentication failure.")
+	}
+	if err != nil {
+		t.Errorf("Unexpected authentication error.")
+	}
+}
+
+func TestHandlerWithOriginIPv6(t *testing.T) {
+	ipMap := map[string]bool{"127.0.0.1": true, "2001:4860:0:2001::68": true}
+	user := "username"
+	bcryptHash := []byte(sampleHash)
+	origin := net.TCPAddr{IP: []byte{
+		0x20, 0x01, 0x48, 0x60, 0, 0, 0x20, 0x01, 0, 0, 0, 0, 0, 0, 0x00, 0x68,
+	}}
+	auth := New(ipMap, user, bcryptHash)
+	success, err := auth.Handler(
+		&origin,
+		"LOGIN",
+		[]byte("username"),
+		[]byte("password"),
+		nil,
+	)
+	if success != true {
+		t.Errorf("Unexpected authentication failure.")
+	}
+	if err != nil {
+		t.Errorf("Unexpected authentication error.")
+	}
+}
+
+func TestHandlerWithInvalidPassword(t *testing.T) {
+	user := "username"
+	bcryptHash := []byte(sampleHash)
+	origin := net.TCPAddr{IP: []byte{127, 0, 0, 1}}
+	auth := New(nil, user, bcryptHash)
+	success, err := auth.Handler(
+		&origin,
+		"LOGIN",
+		[]byte("username"),
+		[]byte("invalid"),
+		nil,
+	)
+	if success != false {
+		t.Errorf("Unexpected password authentication success.")
+	}
+	if err == nil {
+		t.Errorf("Unexpected missing password authentication error.")
+	}
+}
+
+func TestHandlerWithInvalidUsername(t *testing.T) {
+	user := "username"
+	bcryptHash := []byte(sampleHash)
+	origin := net.TCPAddr{IP: []byte{127, 0, 0, 1}}
+	auth := New(nil, user, bcryptHash)
+	success, err := auth.Handler(
+		&origin,
+		"LOGIN",
+		[]byte("invalid"),
+		[]byte("password"),
+		nil,
+	)
+	if success != false {
+		t.Errorf("Unexpected username authentication success.")
+	}
+	if err == nil {
+		t.Errorf("Unexpected missing username authentication error.")
+	}
+}
+
+func TestHandlerWithNonAllowedIP(t *testing.T) {
+	ipMap := map[string]bool{"127.0.0.1": true, "2001:4860:0:2001::68": true}
+	origin := net.TCPAddr{IP: []byte{192, 168, 0, 1}}
+	auth := New(ipMap, "", nil)
+	success, err := auth.Handler(
+		&origin,
+		"",
+		nil,
+		nil,
+		nil,
+	)
+	if success != false {
+		t.Errorf("Unexpected IP authentication success.")
+	}
+	if err == nil {
+		t.Errorf("Unexpected missing IP authentication error.")
+	}
+}
+
+func TestHandlerWithAuthenticationDisabled(t *testing.T) {
+	origin := net.TCPAddr{IP: []byte{127, 0, 0, 1}}
+	auth := New(nil, "", nil)
+	success, err := auth.Handler(
+		&origin,
+		"",
+		nil,
+		nil,
+		nil,
+	)
+	if success != true {
+		t.Errorf("Unexpected IP authentication failure.")
+	}
+	if err != nil {
+		t.Errorf("Unexpected IP authentication error.")
+	}
+}

--- a/internal/relay/pinpoint/relay.go
+++ b/internal/relay/pinpoint/relay.go
@@ -2,45 +2,49 @@ package relay
 
 import (
 	"net"
-	"time"
 
+	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/pinpointemail"
 	"github.com/aws/aws-sdk-go/service/pinpointemail/pinpointemailiface"
-	"github.com/blueimp/aws-smtp-relay/internal/relay"
+	"github.com/blueimp/aws-smtp-relay/internal/request"
 )
 
+// Client implements the Relay interface.
+type Client struct {
+	pinpointAPI pinpointemailiface.PinpointEmailAPI
+	setName     *string
+}
+
 // Send uses the given Pinpoint API to send email data
-func Send(
-	pinpointAPI pinpointemailiface.PinpointEmailAPI,
+func (c Client) Send(
 	origin net.Addr,
-	from *string,
-	to *[]string,
-	data *[]byte,
-	setName *string,
+	from string,
+	to []string,
+	data []byte,
 ) {
-	var err error
-	req := &relay.Request{
-		Time: time.Now().UTC(),
-		Addr: origin,
-		From: *from,
-		To:   *to,
-		Err:  &err,
-	}
-	defer req.Log()
 	destinations := []*string{}
-	for k := range *to {
-		destinations = append(destinations, &(*to)[k])
+	for k := range to {
+		destinations = append(destinations, &(to)[k])
 	}
-	_, err = pinpointAPI.SendEmail(&pinpointemail.SendEmailInput{
-		ConfigurationSetName: setName,
-		FromEmailAddress: from,
+	_, err := c.pinpointAPI.SendEmail(&pinpointemail.SendEmailInput{
+		ConfigurationSetName: c.setName,
+		FromEmailAddress:     &from,
 		Destination: &pinpointemail.Destination{
 			ToAddresses: destinations,
 		},
 		Content: &pinpointemail.EmailContent{
 			Raw: &pinpointemail.RawMessage{
-				Data: *data,
+				Data: data,
 			},
 		},
 	})
+	request.Log(origin, from, to, err)
+}
+
+// New creates a new client with a session.
+func New(configurationSetName *string) Client {
+	return Client{
+		pinpointAPI: pinpointemail.New(session.Must(session.NewSession())),
+		setName:     configurationSetName,
+	}
 }

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -1,35 +1,16 @@
+/*
+Package relay provides an interface to relay emails via Amazon SES/Pinpoint API.
+*/
 package relay
 
-import (
-	"encoding/json"
-	"fmt"
-	"net"
-	"os"
-	"time"
-)
+import "net"
 
-// Request object
-type Request struct {
-	Time  time.Time
-	Addr  net.Addr
-	IP    string
-	From  string
-	To    []string
-	Error string
-	Err   *error
-}
-
-// Log prints the Request data to Stdout/Stderr
-func (req *Request) Log() {
-	req.IP = req.Addr.(*net.TCPAddr).IP.String()
-	var out *os.File
-	err := *req.Err
-	if err != nil {
-		req.Error = err.Error()
-		out = os.Stderr
-	} else {
-		out = os.Stdout
-	}
-	b, _ := json.Marshal(req)
-	fmt.Fprintln(out, string(b))
+// Client provides an interface to send emails.
+type Client interface {
+	Send(
+		origin net.Addr,
+		from string,
+		to []string,
+		data []byte,
+	)
 }

--- a/internal/relay/ses/relay.go
+++ b/internal/relay/ses/relay.go
@@ -2,39 +2,43 @@ package relay
 
 import (
 	"net"
-	"time"
 
+	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ses"
 	"github.com/aws/aws-sdk-go/service/ses/sesiface"
-	"github.com/blueimp/aws-smtp-relay/internal/relay"
+	"github.com/blueimp/aws-smtp-relay/internal/request"
 )
 
-// Send uses the given SESAPI to send email data
-func Send(
-	sesAPI sesiface.SESAPI,
+// Client implements the Relay interface.
+type Client struct {
+	sesAPI  sesiface.SESAPI
+	setName *string
+}
+
+// Send uses the client SESAPI to send email data
+func (c Client) Send(
 	origin net.Addr,
-	from *string,
-	to *[]string,
-	data *[]byte,
-	setName *string,
+	from string,
+	to []string,
+	data []byte,
 ) {
-	var err error
-	req := &relay.Request{
-		Time: time.Now().UTC(),
-		Addr: origin,
-		From: *from,
-		To:   *to,
-		Err:  &err,
-	}
-	defer req.Log()
 	destinations := []*string{}
-	for k := range *to {
-		destinations = append(destinations, &(*to)[k])
+	for k := range to {
+		destinations = append(destinations, &(to)[k])
 	}
-	_, err = sesAPI.SendRawEmail(&ses.SendRawEmailInput{
-		ConfigurationSetName: setName,
-		Source:               from,
+	_, err := c.sesAPI.SendRawEmail(&ses.SendRawEmailInput{
+		ConfigurationSetName: c.setName,
+		Source:               &from,
 		Destinations:         destinations,
-		RawMessage:           &ses.RawMessage{Data: *data},
+		RawMessage:           &ses.RawMessage{Data: data},
 	})
+	request.Log(origin, from, to, err)
+}
+
+// New creates a new client with a session.
+func New(configurationSetName *string) Client {
+	return Client{
+		sesAPI:  ses.New(session.Must(session.NewSession())),
+		setName: configurationSetName,
+	}
 }

--- a/internal/relay/ses/relay_test.go
+++ b/internal/relay/ses/relay_test.go
@@ -1,17 +1,13 @@
-package relay_test
+package relay
 
 import (
-	"encoding/json"
 	"io/ioutil"
 	"net"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/aws/aws-sdk-go/service/ses"
 	"github.com/aws/aws-sdk-go/service/ses/sesiface"
-	"github.com/blueimp/aws-smtp-relay/internal/relay"
-	internal "github.com/blueimp/aws-smtp-relay/internal/relay/ses"
 )
 
 var testData = struct{ input *ses.SendRawEmailInput }{}
@@ -30,10 +26,10 @@ func (m *mockSESAPI) SendRawEmail(input *ses.SendRawEmailInput) (
 
 func sendHelper(
 	origin net.Addr,
-	from *string,
-	to *[]string,
-	data *[]byte,
-	setName *string,
+	from string,
+	to []string,
+	data []byte,
+	configurationSetName *string,
 ) (email *ses.SendRawEmailInput, out []byte, err []byte) {
 	outReader, outWriter, _ := os.Pipe()
 	errReader, errWriter, _ := os.Pipe()
@@ -47,7 +43,8 @@ func sendHelper(
 	os.Stdout = outWriter
 	os.Stderr = errWriter
 	func() {
-		internal.Send(&mockSESAPI{}, origin, from, to, data, setName)
+		c := Client{sesAPI: &mockSESAPI{}, setName: configurationSetName}
+		c.Send(origin, from, to, data)
 		outWriter.Close()
 		errWriter.Close()
 	}()
@@ -62,9 +59,7 @@ func TestSend(t *testing.T) {
 	to := []string{"bob@example.org"}
 	data := []byte{'T', 'E', 'S', 'T'}
 	setName := ""
-	timeBefore := time.Now()
-	input, out, err := sendHelper(&origin, &from, &to, &data, &setName)
-	timeAfter := time.Now()
+	input, out, err := sendHelper(&origin, from, to, data, &setName)
 	if *input.Source != from {
 		t.Errorf(
 			"Unexpected source: %s. Expected: %s",
@@ -83,51 +78,8 @@ func TestSend(t *testing.T) {
 	if inputData != "TEST" {
 		t.Errorf("Unexpected data: %s. Expected: %s", inputData, "TEST")
 	}
-	var req relay.Request
-	json.Unmarshal(out, &req)
-	if req.Time.Before(timeBefore) {
-		t.Errorf("Unexpected 'Time' log: %s", req.Time)
-	}
-	if req.Time.After(timeAfter) {
-		t.Errorf("Unexpected 'Time' log: %s", req.Time)
-	}
-	if req.IP != "127.0.0.1" {
-		t.Errorf("Unexpected 'IP' log: %s. Expected: %s", req.IP, "127.0.0.1")
-	}
-	if req.From != from {
-		t.Errorf("Unexpected 'From' log: %s. Expected: %s", req.From, from)
-	}
-	if req.To[0] != to[0] {
-		t.Errorf("Unexpected 'To' log: %s. Expected: %s", req.To, to)
-	}
-	if req.Error != "" {
-		t.Errorf("Unexpected 'Error' log: %s. Expected: %s", req.Error, "")
-	}
-	if len(err) != 0 {
-		t.Errorf("Unexpected stderr: %s", err)
-	}
-}
-
-func TestSendWithOriginIPv6(t *testing.T) {
-	origin := net.TCPAddr{IP: []byte{
-		0x20, 0x01, 0x48, 0x60, 0, 0, 0x20, 0x01, 0, 0, 0, 0, 0, 0, 0x00, 0x68,
-	}}
-	from := "alice@example.org"
-	to := []string{"bob@example.org"}
-	data := []byte{'T', 'E', 'S', 'T'}
-	setName := ""
-	_, out, err := sendHelper(&origin, &from, &to, &data, &setName)
-	var req relay.Request
-	json.Unmarshal(out, &req)
-	if req.IP != "2001:4860:0:2001::68" {
-		t.Errorf(
-			"Unexpected 'IP' log: %s. Expected: %s",
-			req.IP,
-			"2001:4860:0:2001::68",
-		)
-	}
-	if req.Error != "" {
-		t.Errorf("Unexpected 'Error' log: %s. Expected: %s", req.Error, "")
+	if len(out) == 0 {
+		t.Error("Unexpected empty stdout")
 	}
 	if len(err) != 0 {
 		t.Errorf("Unexpected stderr: %s", err)
@@ -140,7 +92,7 @@ func TestSendWithMultipleRecipients(t *testing.T) {
 	to := []string{"bob@example.org", "charlie@example.org"}
 	data := []byte{'T', 'E', 'S', 'T'}
 	setName := ""
-	input, out, err := sendHelper(&origin, &from, &to, &data, &setName)
+	input, out, err := sendHelper(&origin, from, to, data, &setName)
 	if len(input.Destinations) != 2 {
 		t.Errorf(
 			"Unexpected number of destinations: %d. Expected: %d",
@@ -155,13 +107,8 @@ func TestSendWithMultipleRecipients(t *testing.T) {
 			to[0],
 		)
 	}
-	var req relay.Request
-	json.Unmarshal(out, &req)
-	if req.To[0] != to[0] {
-		t.Errorf("Unexpected 'To' log: %s. Expected: %s", req.To, to)
-	}
-	if req.Error != "" {
-		t.Errorf("Unexpected 'Error' log: %s. Expected: %s", req.Error, "")
+	if len(out) == 0 {
+		t.Error("Unexpected empty stdout")
 	}
 	if len(err) != 0 {
 		t.Errorf("Unexpected stderr: %s", err)

--- a/internal/request/request.go
+++ b/internal/request/request.go
@@ -1,0 +1,35 @@
+/*
+Package request provides a simple JSON logger for SMTP requests.
+*/
+package request
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"time"
+)
+
+type logEntry struct {
+	Time  time.Time
+	IP    string
+	From  string
+	To    []string
+	Error string
+}
+
+// Log creates a log entry and prints it as JSON to STDOUT.
+func Log(origin net.Addr, from string, to []string, err error) {
+	ip := origin.(*net.TCPAddr).IP.String()
+	entry := &logEntry{
+		Time: time.Now().UTC(),
+		IP:   ip,
+		From: from,
+		To:   to,
+	}
+	if err != nil {
+		entry.Error = err.Error()
+	}
+	b, _ := json.Marshal(entry)
+	fmt.Println(string(b))
+}

--- a/internal/request/request_test.go
+++ b/internal/request/request_test.go
@@ -1,0 +1,106 @@
+package request
+
+import (
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"net"
+	"os"
+	"testing"
+	"time"
+)
+
+func logHelper(addr net.Addr, from string, to []string, err error) (
+	[]byte,
+	[]byte,
+) {
+	outReader, outWriter, _ := os.Pipe()
+	errReader, errWriter, _ := os.Pipe()
+	originalOut := os.Stdout
+	originalErr := os.Stderr
+	defer func() {
+		os.Stdout = originalOut
+		os.Stderr = originalErr
+	}()
+	os.Stdout = outWriter
+	os.Stderr = errWriter
+	func() {
+		Log(addr, from, to, err)
+		outWriter.Close()
+		errWriter.Close()
+	}()
+	stdout, _ := ioutil.ReadAll(outReader)
+	stderr, _ := ioutil.ReadAll(errReader)
+	return stdout, stderr
+}
+
+func TestLog(t *testing.T) {
+	origin := net.TCPAddr{IP: []byte{127, 0, 0, 1}}
+	from := "alice@example.org"
+	to := []string{"bob@example.org", "charlie@example.org"}
+	timeBefore := time.Now()
+	out, err := logHelper(&origin, from, to, nil)
+	timeAfter := time.Now()
+	var entry logEntry
+	json.Unmarshal(out, &entry)
+	if entry.Time.Before(timeBefore) {
+		t.Errorf("Unexpected 'Time' log: %s", entry.Time)
+	}
+	if entry.Time.After(timeAfter) {
+		t.Errorf("Unexpected 'Time' log: %s", entry.Time)
+	}
+	if entry.IP != "127.0.0.1" {
+		t.Errorf("Unexpected 'IP' log: %s. Expected: %s", entry.IP, "127.0.0.1")
+	}
+	if entry.From != from {
+		t.Errorf("Unexpected 'From' log: %s. Expected: %s", entry.From, from)
+	}
+	if entry.To[0] != to[0] {
+		t.Errorf("Unexpected 'To' log: %s. Expected: %s", entry.To, to)
+	}
+	if entry.Error != "" {
+		t.Errorf("Unexpected 'Error' log: %s. Expected: %s", entry.Error, "")
+	}
+	if len(err) != 0 {
+		t.Errorf("Unexpected stderr: %s", err)
+	}
+}
+
+func TestLogWithOriginIPv6(t *testing.T) {
+	origin := net.TCPAddr{IP: []byte{
+		0x20, 0x01, 0x48, 0x60, 0, 0, 0x20, 0x01, 0, 0, 0, 0, 0, 0, 0x00, 0x68,
+	}}
+	from := "alice@example.org"
+	to := []string{"bob@example.org", "charlie@example.org"}
+	out, err := logHelper(&origin, from, to, nil)
+	var entry logEntry
+	json.Unmarshal(out, &entry)
+	if entry.IP != "2001:4860:0:2001::68" {
+		t.Errorf(
+			"Unexpected 'IP' log: %s. Expected: %s",
+			entry.IP,
+			"2001:4860:0:2001::68",
+		)
+	}
+	if entry.Error != "" {
+		t.Errorf("Unexpected 'Error' log: %s. Expected: %s", entry.Error, "")
+	}
+	if len(err) != 0 {
+		t.Errorf("Unexpected stderr: %s", err)
+	}
+}
+
+func TestLogWithError(t *testing.T) {
+	origin := net.TCPAddr{IP: []byte{127, 0, 0, 1}}
+	from := "alice@example.org"
+	to := []string{"bob@example.org", "charlie@example.org"}
+	out, err := logHelper(&origin, from, to, errors.New("ERROR"))
+	var entry logEntry
+	json.Unmarshal(out, &entry)
+	if entry.Error != "ERROR" {
+		t.Errorf("Unexpected 'Error' log: %s. Expected: %s", entry.Error, "ERROR")
+	}
+	if len(err) != 0 {
+		t.Errorf("Unexpected stderr: %s", err)
+	}
+}

--- a/main_internal_test.go
+++ b/main_internal_test.go
@@ -1,17 +1,20 @@
 package main
 
 import (
+	"flag"
 	"io/ioutil"
-	"net"
 	"os"
 	"testing"
+
+	pinpointrelay "github.com/blueimp/aws-smtp-relay/internal/relay/pinpoint"
+	sesrelay "github.com/blueimp/aws-smtp-relay/internal/relay/ses"
 )
 
 // bcrypt hash for the string "password"
 var sampleHash = "$2y$10$85/eICRuwBwutrou64G5HeoF3Ek/qf1YKPLba7ckiMxUTAeLIeyaC"
 
-func createTmpFile(content string) (file *os.File, err error) {
-	file, err = ioutil.TempFile("", "")
+func createTmpFile(content string) (fileName *string, err error) {
+	file, err := ioutil.TempFile("", "")
 	if err != nil {
 		return
 	}
@@ -20,12 +23,14 @@ func createTmpFile(content string) (file *os.File, err error) {
 		return
 	}
 	err = file.Close()
+	name := file.Name()
+	fileName = &name
 	return
 }
 
 func createTLSFiles() (
-	certFile *os.File,
-	keyFile *os.File,
+	certFile *string,
+	keyFile *string,
 	passphrase string,
 	err error,
 ) {
@@ -91,9 +96,109 @@ uEGsi+l2fTj/F+eZLE6sYoMprgJrbfeqtRWFguUgTn7s5hfU0tZ46al5d0vz8fWK
 	return
 }
 
-func TestServer(t *testing.T) {
+func resetHelper() {
 	os.Args = []string{"noop"}
-	parseArgs()
+	flag.Parse()
+	*addr = ":1025"
+	*name = "AWS SMTP Relay"
+	*host = ""
+	*certFile = ""
+	*keyFile = ""
+	*startTLS = false
+	*onlyTLS = false
+	*relayAPI = "ses"
+	*setName = ""
+	*ips = ""
+	*user = ""
+	ipMap = nil
+	bcryptHash = nil
+	relayClient = nil
+	os.Unsetenv("BCRYPT_HASH")
+	os.Unsetenv("TLS_KEY_PASS")
+}
+
+func TestConfigure(t *testing.T) {
+	resetHelper()
+	err := configure()
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	if *user != "" {
+		t.Errorf("Unexpected username: %s", *user)
+	}
+	if string(bcryptHash) != "" {
+		t.Errorf("Unexpected bhash: %s", string(bcryptHash))
+	}
+	if *ips != "" {
+		t.Errorf("Unexpected IPs string: %s", *ips)
+	}
+	if len(ipMap) != 0 {
+		t.Errorf("Unexpected IP map size: %d", len(ipMap))
+	}
+	_, ok := interface{}(relayClient).(sesrelay.Client)
+	if !ok {
+		t.Error("Unexpected: relayClient function is not an sesrelay.Client")
+	}
+	if string(bcryptHash) != "" {
+		t.Errorf("Unexpected bhash: %s", string(bcryptHash))
+	}
+}
+
+func TestConfigureWithPinpointRelay(t *testing.T) {
+	resetHelper()
+	*relayAPI = "pinpoint"
+	err := configure()
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	_, ok := interface{}(relayClient).(pinpointrelay.Client)
+	if !ok {
+		t.Error("Unexpected: relayClient function is not an sesrelay.Client")
+	}
+}
+
+func TestConfigureWithInvalidRelay(t *testing.T) {
+	resetHelper()
+	*relayAPI = "invalid"
+	err := configure()
+	if err == nil {
+		t.Error("Unexpected nil error")
+	}
+	if relayClient != nil {
+		t.Errorf("Unexpected relay client: %s", relayClient)
+	}
+}
+
+func TestConfigureWithBcryptHash(t *testing.T) {
+	resetHelper()
+	os.Setenv("BCRYPT_HASH", sampleHash)
+	err := configure()
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	if string(bcryptHash) != sampleHash {
+		t.Errorf("Unexpected bhash: %s", string(bcryptHash))
+	}
+}
+
+func TestConfigureWithIPs(t *testing.T) {
+	resetHelper()
+	*ips = "127.0.0.1,2001:4860:0:2001::68"
+	err := configure()
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	if *ips != "127.0.0.1,2001:4860:0:2001::68" {
+		t.Errorf("Unexpected IPs string: %s", *ips)
+	}
+	if len(ipMap) != 2 {
+		t.Errorf("Unexpected IP map size: %d", len(ipMap))
+	}
+}
+
+func TestServer(t *testing.T) {
+	resetHelper()
+	configure()
 	srv, err := server()
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
@@ -116,181 +221,67 @@ func TestServer(t *testing.T) {
 	if srv.TLSListener != false {
 		t.Errorf("Unexpected TLS listener: %t", srv.TLSListener)
 	}
-	if *user != "" {
-		t.Errorf("Unexpected username: %s", *user)
-	}
-	if string(bcryptHash) != "" {
-		t.Errorf("Unexpected bhash: %s", string(bcryptHash))
-	}
-	if *ips != "" {
-		t.Errorf("Unexpected IPs string: %s", *ips)
-	}
-	if len(ipMap) != 0 {
-		t.Errorf("Unexpected IP map size: %d", len(ipMap))
-	}
-	os.Args = append(
-		[]string{"noop"},
-		"-a",
-		"127.0.0.1:25",
-		"-n",
-		"BANANA",
-		"-h",
-		"localhost",
-		"-s",
-		"-t",
-		"-u",
-		"username",
-		"-i",
-		"127.0.0.1,2001:4860:0:2001::68",
-	)
-	os.Setenv("BCRYPT_HASH", sampleHash)
-	parseArgs()
-	srv, err = server()
+}
+
+func TestServerWithCustomAddress(t *testing.T) {
+	resetHelper()
+	*addr = "127.0.0.1:25"
+	configure()
+	srv, err := server()
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
-	if srv.Addr != os.Args[2] {
-		t.Errorf("Unexpected addr: %s. Expected: %s", srv.Addr, os.Args[2])
+	if srv.Addr != *addr {
+		t.Errorf("Unexpected addr: %s. Expected: %s", srv.Addr, *addr)
 	}
-	if srv.Appname != os.Args[4] {
-		t.Errorf("Unexpected addr: %s. Expected: %s", srv.Appname, os.Args[4])
+}
+
+func TestServerWithCustomAppname(t *testing.T) {
+	resetHelper()
+	*name = "Custom Appname"
+	configure()
+	srv, err := server()
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
 	}
-	if srv.Hostname != os.Args[6] {
-		t.Errorf("Unexpected host: %s. Expected: %s", srv.Hostname, os.Args[6])
+	if srv.Appname != "Custom Appname" {
+		t.Errorf("Unexpected addr: %s. Expected: %s", srv.Appname, "Custom Appname")
 	}
-	if srv.TLSRequired != true {
-		t.Errorf("Unexpected TLS required: %t", srv.TLSRequired)
+}
+
+func TestServerWithCustomHostname(t *testing.T) {
+	resetHelper()
+	*host = "test"
+	configure()
+	srv, err := server()
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
 	}
-	if srv.TLSListener != true {
-		t.Errorf("Unexpected TLS listener: %t", srv.TLSListener)
+	if srv.Hostname != "test" {
+		t.Errorf("Unexpected host: %s. Expected: %s", srv.Hostname, "test")
 	}
-	if *user != "username" {
-		t.Errorf("Unexpected username: %s", *user)
-	}
-	if string(bcryptHash) != sampleHash {
-		t.Errorf("Unexpected bhash: %s", string(bcryptHash))
-	}
-	if *ips != "127.0.0.1,2001:4860:0:2001::68" {
-		t.Errorf("Unexpected IPs string: %s", *ips)
-	}
-	if len(ipMap) != 2 {
-		t.Errorf("Unexpected IP map size: %d", len(ipMap))
-	}
-	certFile, keyFile, passphrase, err := createTLSFiles()
+}
+
+func TestServerWithTLS(t *testing.T) {
+	resetHelper()
+	var passphrase string
+	var err error
+	certFile, keyFile, passphrase, err = createTLSFiles()
 	if err != nil {
 		t.Errorf("Unexpected TLS files creation error: %s", err)
 		return
 	}
 	defer func() {
-		os.Remove(certFile.Name())
-		os.Remove(keyFile.Name())
+		os.Remove(*certFile)
+		os.Remove(*keyFile)
 	}()
-	os.Args = append(
-		[]string{"noop"},
-		"-c",
-		certFile.Name(),
-		"-k",
-		keyFile.Name(),
-	)
 	os.Setenv("TLS_KEY_PASS", passphrase)
-	parseArgs()
-	srv, err = server()
+	configure()
+	srv, err := server()
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
 	if srv.TLSConfig == nil {
 		t.Errorf("Unexpected empty TLS config.")
-	}
-}
-
-func TestAuthHandler(t *testing.T) {
-	*user = "username"
-	*ips = "127.0.0.1,2001:4860:0:2001::68"
-	ipMap = map[string]bool{"127.0.0.1": true, "2001:4860:0:2001::68": true}
-	bcryptHash = []byte(sampleHash)
-	origin := net.TCPAddr{IP: []byte{127, 0, 0, 1}}
-	success, err := authHandler(
-		&origin,
-		"LOGIN",
-		[]byte("username"),
-		[]byte("password"),
-		nil,
-	)
-	if success != true {
-		t.Errorf("Unexpected authentication failure.")
-	}
-	if err != nil {
-		t.Errorf("Unexpected authentication error.")
-	}
-	origin = net.TCPAddr{IP: []byte{
-		0x20, 0x01, 0x48, 0x60, 0, 0, 0x20, 0x01, 0, 0, 0, 0, 0, 0, 0x00, 0x68,
-	}}
-	success, err = authHandler(
-		&origin,
-		"LOGIN",
-		[]byte("username"),
-		[]byte("password"),
-		nil,
-	)
-	if success != true {
-		t.Errorf("Unexpected authentication failure.")
-	}
-	if err != nil {
-		t.Errorf("Unexpected authentication error.")
-	}
-	success, err = authHandler(
-		&origin,
-		"LOGIN",
-		[]byte("username"),
-		[]byte("invalid"),
-		nil,
-	)
-	if success != false {
-		t.Errorf("Unexpected password authentication success.")
-	}
-	if err == nil {
-		t.Errorf("Unexpected missing password authentication error.")
-	}
-	success, err = authHandler(
-		&origin,
-		"LOGIN",
-		[]byte("invalid"),
-		[]byte("password"),
-		nil,
-	)
-	if success != false {
-		t.Errorf("Unexpected username authentication success.")
-	}
-	if err == nil {
-		t.Errorf("Unexpected missing username authentication error.")
-	}
-	*user = ""
-	origin = net.TCPAddr{IP: []byte{192, 168, 0, 1}}
-	success, err = authHandler(
-		&origin,
-		"",
-		nil,
-		nil,
-		nil,
-	)
-	if success != false {
-		t.Errorf("Unexpected IP authentication success.")
-	}
-	if err == nil {
-		t.Errorf("Unexpected missing IP authentication error.")
-	}
-	*ips = ""
-	success, err = authHandler(
-		&origin,
-		"",
-		nil,
-		nil,
-		nil,
-	)
-	if success != true {
-		t.Errorf("Unexpected IP authentication failure.")
-	}
-	if err != nil {
-		t.Errorf("Unexpected IP authentication error.")
 	}
 }

--- a/main_internal_test.go
+++ b/main_internal_test.go
@@ -91,8 +91,9 @@ uEGsi+l2fTj/F+eZLE6sYoMprgJrbfeqtRWFguUgTn7s5hfU0tZ46al5d0vz8fWK
 	return
 }
 
-func TestOptions(t *testing.T) {
+func TestServer(t *testing.T) {
 	os.Args = []string{"noop"}
+	parseArgs()
 	srv, err := server()
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
@@ -143,6 +144,7 @@ func TestOptions(t *testing.T) {
 		"127.0.0.1,2001:4860:0:2001::68",
 	)
 	os.Setenv("BCRYPT_HASH", sampleHash)
+	parseArgs()
 	srv, err = server()
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
@@ -191,6 +193,7 @@ func TestOptions(t *testing.T) {
 		keyFile.Name(),
 	)
 	os.Setenv("TLS_KEY_PASS", passphrase)
+	parseArgs()
 	srv, err = server()
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)


### PR DESCRIPTION
Provide factory functions to create a relay client.
Use the smtpd.Handler function signature for relay.Client.Send.
Refactor the logging functionality and move it into a separate package.
Move arguments parsing into a separate function.
Add links to Pinpoint Email API and SMTP interface.
Fix the usage documentation.